### PR TITLE
Add mocha testing framework and health test

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -99,6 +99,10 @@ app.get("/:id", getWeather("cli"));
 app.get("/button/:id", getWeather("button"));
 app.get("/api/:id", getWeather("api"));
 
-app.listen(port, () => {
-  console.log(`Server is running on port ${port}`);
-});
+if (require.main === module) {
+  app.listen(port, () => {
+    console.log(`Server is running on port ${port}`);
+  });
+}
+
+module.exports = app;

--- a/app/package.json
+++ b/app/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "mocha"
   },
   "keywords": [],
   "author": "",
@@ -17,5 +17,9 @@
     "express-memjs-cache": "^1.0.0",
     "morgan": "^1.10.0",
     "nocache": "^4.0.0"
+  },
+  "devDependencies": {
+    "mocha": "^10.2.0",
+    "supertest": "^6.3.3"
   }
 }

--- a/app/test/health.test.js
+++ b/app/test/health.test.js
@@ -1,0 +1,11 @@
+const request = require('supertest');
+const app = require('../index');
+
+describe('GET /health', function () {
+  it('responds with OK', function (done) {
+    request(app)
+      .get('/health')
+      .expect(200)
+      .expect('OK', done);
+  });
+});


### PR DESCRIPTION
## Summary
- add mocha/supertest as dev deps
- export Express app from `index.js`
- add `/health` endpoint test
- run tests with `npm test`

## Testing
- `npm test` *(fails: mocha not found)*